### PR TITLE
nat46: only set priv_flags_ext where the kernel has it

### DIFF
--- a/package/kernel/nat46/Makefile
+++ b/package/kernel/nat46/Makefile
@@ -39,10 +39,18 @@ define Build/InstallDev
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/nat46/modules/*.h  $(STAGING_DIR)/usr/include/nat46/
 endef
 
+# The MAP-T fast path marks its netdev with dev->priv_flags_ext =
+# IFF_EXT_MAPT. Both the field and the flag come from the QCA ECM kernel
+# patch (qca-nss-ecm-support-CORE), which only the NSS targets carry, so
+# probe the kernel headers rather than assume them: without the patch the
+# module still builds, it just does not set the flag nothing reads.
+# Lazily assigned - LINUX_DIR only holds a prepared kernel at build time.
+NAT46_PRIV_FLAGS_EXT = $(shell grep -qs 'priv_flags_ext' $(LINUX_DIR)/include/linux/netdevice.h && echo -DNAT46_HAVE_PRIV_FLAGS_EXT)
+
 define Build/Compile
 	+$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)/nat46/modules" \
 		MODFLAGS="-DMODULE -mlong-calls" \
-		EXTRA_CFLAGS="-DNAT46_VERSION=\\\"$(PKG_SOURCE_VERSION)\\\"" \
+		EXTRA_CFLAGS="-DNAT46_VERSION=\\\"$(PKG_SOURCE_VERSION)\\\" $(NAT46_PRIV_FLAGS_EXT)" \
 		modules
 endef
 

--- a/package/kernel/nat46/patches/118-performance_fix.patch
+++ b/package/kernel/nat46/patches/118-performance_fix.patch
@@ -415,11 +415,13 @@ Date: Fri Dec 17 13:37:15 2021 -0800
  		ret = nat46_ipv6_input(skb);
  	}
  	if(0 == ret) {
-@@ -188,6 +187,7 @@ static void nat46_netdev_setup(struct ne
+@@ -188,6 +187,9 @@ static void nat46_netdev_setup(struct ne
  	dev->netns_immutable = true;
  #endif
  	dev->flags = IFF_NOARP | IFF_POINTOPOINT;
++#ifdef NAT46_HAVE_PRIV_FLAGS_EXT
 +	dev->priv_flags_ext = IFF_EXT_MAPT;
++#endif
  }
  
  static int nat46_netdev_create(struct net *net, char *basename, struct net_device **dev)


### PR DESCRIPTION
`118-performance_fix.patch` marks the MAP-T netdev with `dev->priv_flags_ext = IFF_EXT_MAPT`. Both the field and the flag come from the QCA ECM kernel patch (`qca-nss-ecm-support-CORE`), which lives in `target/linux/qualcommax` only, so on every other target the package fails to build:

```
nat46-netdev.c:190:14: error: 'struct net_device' has no member named 'priv_flags_ext'; did you mean 'priv_flags_fast'?
nat46-netdev.c:190:31: error: 'IFF_EXT_MAPT' undeclared (first use in this function)
```

That is what breaks the *Build all core packages* job for `malta/be` and `x86/64` - `kmod-nat46` is a core package and gets built on targets that have no NSS patches at all.

`IFF_EXT_MAPT` is an enum constant, so the preprocessor cannot test for it. This probes the prepared kernel headers from the package Makefile instead and passes `-DNAT46_HAVE_PRIV_FLAGS_EXT` when the field is present; the assignment is compiled only under that. Where the ECM patch is absent the module builds and behaves as before, since nothing in such a tree reads the flag.

Verified both ways against real headers: a qualcommax 6.18.44 build tree sets the define, pristine 6.18.44 from `dl/` does not, and the full nat46 patch series still applies to the pinned source with the guard in place.