### PR TITLE
mac80211: ath11k: load PCI transport from NSS init script

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -484,7 +484,6 @@ define KernelPackage/ath11k-pci
   URL:=https://wireless.wiki.kernel.org/en/users/drivers/ath11k
   DEPENDS+= @PCI_SUPPORT +kmod-qrtr-mhi +kmod-ath11k
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath11k/ath11k_pci.ko
-  AUTOLOAD:=$(call AutoProbe,ath11k_pci)
 endef
 
 define KernelPackage/ath11k-pci/description

--- a/package/nss/nss-tools/files/nss.init
+++ b/package/nss/nss-tools/files/nss.init
@@ -30,6 +30,7 @@ wifi_load_host() {
 	modprobe ath11k 2>/dev/null
 	[ -w $NSSOFF ] && echo 0 > $NSSOFF
 	modprobe ath11k_ahb 2>/dev/null
+	modprobe ath11k_pci 2>/dev/null
 }
 
 start_service() {
@@ -71,6 +72,7 @@ start_service() {
 	[ -w $NSSOFF ] && echo "$wifi_offload" > $NSSOFF
 	/etc/init.d/qca-nss-pbuf start >/dev/null 2>&1
 	modprobe ath11k_ahb 2>/dev/null
+	modprobe ath11k_pci 2>/dev/null
 
 	procd_open_instance nss-up
 	procd_set_param command /usr/sbin/nss-up


### PR DESCRIPTION
Stop auto loading ath11k_pci and load it from nss.init immediately after ath11k_ahb on both the NSS and host fallback path.

During testing with RBRE960 that contains QCN9074 PCIE based 6GHz radio ath11k_pci loaded before ath11k.
With NSS enabled this ordering led to firmware crashes.
